### PR TITLE
performance improvements, puzzle fixes

### DIFF
--- a/spamdb/modules/blog.py
+++ b/spamdb/modules/blog.py
@@ -1,5 +1,6 @@
 import pymongo
 import random
+import argparse
 from datetime import datetime
 from datetime import timedelta
 from modules.event import evt
@@ -8,8 +9,14 @@ import modules.forum as forum
 import modules.util as util
 
 
-def create_blog_colls(db: pymongo.MongoClient, num_blogs: int) -> None:
-    if num_blogs < 1:
+def create_blog_colls(
+    db: pymongo.MongoClient, args: argparse.Namespace
+) -> None:
+    if args.drop == "blog" or args.drop == "all":
+        db.ublog_blog.drop()
+        db.ublog_post.drop()
+
+    if args.blogs < 1 or args.no_create:
         return
 
     ublogs: list = []
@@ -21,7 +28,7 @@ def create_blog_colls(db: pymongo.MongoClient, num_blogs: int) -> None:
     categ.hidden = True
 
     for (num_posts, uid) in zip(
-        util.random_partition(num_blogs, len(gen.uids), 0), gen.uids
+        util.random_partition(args.blogs, len(gen.uids), 0), gen.uids
     ):
         if num_posts == 0:
             continue
@@ -58,9 +65,9 @@ def create_blog_colls(db: pymongo.MongoClient, num_blogs: int) -> None:
     util.bulk_write(db.ublog_post, uposts)
 
 
-def drop(db: pymongo.MongoClient) -> None:
-    db.ublog_blog.drop()
-    db.ublog_post.drop()
+# def drop(db: pymongo.MongoClient) -> None:
+#     db.ublog_blog.drop()
+#     db.ublog_post.drop()
 
 
 class UBlog:

--- a/spamdb/modules/event.py
+++ b/spamdb/modules/event.py
@@ -1,12 +1,24 @@
 import enum
 import bson
 import pymongo
+import argparse
 from datetime import datetime
 import modules.util as util
 from modules.datasrc import gen
 
 
-def create_event_colls(db: pymongo.MongoClient) -> None:
+def create_event_colls(
+    db: pymongo.MongoClient, args: argparse.Namespace
+) -> None:
+    if args.drop == "event" or args.drop == "all":
+        print("drop event")
+        db.activity2.drop()
+        db.timeline_entry.drop()
+        db.relation.drop()
+
+    if args.no_create:
+        return
+
     activities: list[dict] = []
     relations: list[Relation] = []
 
@@ -20,13 +32,7 @@ def create_event_colls(db: pymongo.MongoClient) -> None:
     util.bulk_write(db.timeline_entry, evt.timeline)
 
 
-def drop(db: pymongo.MongoClient) -> None:
-    db.activity2.drop()
-    db.timeline_entry.drop()
-    db.relation.drop()
-
-
-# singleton evt, collects activity and timeline collections
+# singleton EventApi, collects activity and timeline entries from other modules
 class EventApi:
     def __init__(self):
         self.relation_map: dict[str, list[str]] = {}

--- a/spamdb/modules/forum.py
+++ b/spamdb/modules/forum.py
@@ -1,14 +1,25 @@
 import pymongo
 import random
+import argparse
 from datetime import datetime
 from modules.event import evt
 from modules.datasrc import gen
 import modules.util as util
 
 
-def create_forum_colls(db: pymongo.MongoClient, num_posts: int) -> None:
+def create_forum_colls(
+    db: pymongo.MongoClient, args: argparse.Namespace
+) -> None:
 
-    if num_posts < 1:
+    if args.drop == "forum" or args.drop == "all":
+        db.f_categ.drop()
+        db.f_topic.drop()
+        db.f_post.drop()
+
+    if args.posts < 1:
+        return
+
+    if args.no_create:
         return
 
     categs: dict[str, Categ] = {}
@@ -22,7 +33,8 @@ def create_forum_colls(db: pymongo.MongoClient, num_posts: int) -> None:
 
     for topic_name in gen.topics:
         topics.append(Topic(topic_name, random.choice(list(categs.keys()))))
-    for _ in range(num_posts):
+
+    for _ in range(args.posts):
         p = Post(gen.random_uid())
         posts.append(p)
         t = random.choice(topics)
@@ -36,12 +48,6 @@ def create_forum_colls(db: pymongo.MongoClient, num_posts: int) -> None:
     util.bulk_write(db.f_categ, categs.values())
     util.bulk_write(db.f_topic, topics)
     util.bulk_write(db.f_post, posts)
-
-
-def drop(db: pymongo.MongoClient) -> None:
-    db.f_categ.drop()
-    db.f_topic.drop()
-    db.f_post.drop()
 
 
 class Post:

--- a/spamdb/modules/perf.py
+++ b/spamdb/modules/perf.py
@@ -2,7 +2,6 @@ import random
 import datetime
 import modules.util as util
 
-# should probably be in game.py but it's here because reasons
 types: list[list[int, str, float]] = [
     [0, "ultrabullet", 0.05],
     [1, "bullet", 0.1],

--- a/spamdb/modules/tour.py
+++ b/spamdb/modules/tour.py
@@ -1,19 +1,26 @@
 import pymongo
 import random
+import argparse
 from datetime import datetime
 import modules.util as util
 from modules.datasrc import gen
 from modules.event import evt
 
 
-#   for each tournament, tracks tournament name, status, clock {limit: secs, increment: secs}
-#   length, number of players, conditions: { nbRatedGame {nb: 20, perf: <perf-type>},
-#   creation date, starts at, winner, schedule: {freq: hourly, speed: rapid/classical },
-#   and an id called "featured" which is a gameId i believe (dangerous to fabricate/map?)
+def create_tour_colls(
+    db: pymongo.MongoClient, args: argparse.Namespace
+) -> None:
+    if args.tours == 0:
+        return
 
+    if args.drop == "tour" or args.drop == "all":
+        db.tournament2.drop()
+        db.tournament_leaderboard.drop()
+        db.tournament_pairing.drop()
+        db.tournament_player.drop()
+        db.trophy.drop()
 
-def create_tour_colls(db: pymongo.MongoClient, num_tours: int) -> None:
-    if num_tours == 0:
+    if args.no_create:
         return
 
     tours: list[Tournament] = []
@@ -22,7 +29,7 @@ def create_tour_colls(db: pymongo.MongoClient, num_tours: int) -> None:
     leaderboards: list[TournamentLeaderboard] = []
     trophies: list[Trophy] = []
 
-    for _ in range(num_tours):
+    for _ in range(args.tours):
         t = Tournament()
         tours.append(t)
 
@@ -49,14 +56,6 @@ def create_tour_colls(db: pymongo.MongoClient, num_tours: int) -> None:
     util.bulk_write(db.tournament_leaderboard, leaderboards)
     util.bulk_write(db.tournament_pairing, pairings)
     util.bulk_write(db.tournament_player, players)
-
-
-def drop(db: pymongo.MongoClient) -> None:
-    db.tournament2.drop()
-    db.tournament_leaderboard.drop()
-    db.tournament_pairing.drop()
-    db.tournament_player.drop()
-    db.trophy.drop()
 
 
 class Tournament:

--- a/spamdb/modules/user.py
+++ b/spamdb/modules/user.py
@@ -2,6 +2,7 @@ import bson
 import base64
 import pymongo
 import random
+import argparse
 from sys import stdout
 from datetime import datetime
 from modules.datasrc import gen
@@ -10,14 +11,27 @@ import modules.perf as perf
 import modules.util as util
 
 
-def create_user_colls(db: pymongo.MongoClient, follow_factor: float) -> None:
-    print("Mining bitcoin", sep="", end="", flush=True)  # hash progress
+def create_user_colls(
+    db: pymongo.MongoClient, args: argparse.Namespace
+) -> None:
+
+    if args.drop == "user" or args.drop == "all":
+        db.perf_stat.drop()
+        db.pref.drop()
+        db.ranking.drop()
+        db.history4.drop()
+        db.user4.drop()
+
+    if args.no_create:
+        return
 
     users: list[User] = []
     rankings: list[perf.Ranking] = []
     perfs: list[perf.Perf] = []
     # TODO relations: list[Relation] = []
     history: list[History] = []
+
+    follow_factor = args.follow
 
     for uid in gen.uids:
         users.append(User(uid))
@@ -32,20 +46,11 @@ def create_user_colls(db: pymongo.MongoClient, follow_factor: float) -> None:
         for f in random.sample(gen.uids, int(follow_factor * len(gen.uids))):
             evt.follow(u._id, util.time_since(u.createdAt), f)
 
-    print()
     util.bulk_write(db.pref, [Pref(u._id) for u in users])
     util.bulk_write(db.user4, users)
     util.bulk_write(db.ranking, rankings)
     util.bulk_write(db.perf_stat, perfs)
     util.bulk_write(db.history4, history)
-
-
-def drop(db: pymongo.MongoClient) -> None:
-    db.perf_stat.drop()
-    db.pref.drop()
-    db.ranking.drop()
-    db.history4.drop()
-    db.user4.drop()
 
 
 class User:
@@ -137,7 +142,7 @@ class User:
 
     def detach_perfs(
         self,
-    ) -> list[perf.Perf]:  # build perfs here, but they aren't stored in user4
+    ) -> list[perf.Perf]:
         detached_list: list[perf.Perf] = list(self.perfStats.values())
         delattr(self, "perfStats")
         return detached_list
@@ -162,8 +167,9 @@ class User:
         users.append(User("teacher", [], ["ROLE_TEACHER"], False))
         users.append(User("kid", [], [], False))
         users[-1].kid = True
-        users.append(User("bot", [], [], False))
-        users[-1].title = "BOT"
+        for i in range(10):
+            users.append(User(f"bot{i}", [], [], False))
+            users[-1].title = "BOT"
         users.append(User("wide", [], [], False))
         users[-1].username = "WWWWWWWWWWWWWWWWWWWW"  # widest possible i think
         users[-1].title = "WGM"
@@ -190,9 +196,7 @@ class History:
             return
         for (name, perf) in u.perfs.items():
             newR = u.perfs[name]["gl"]["r"]
-            origR = min(
-                3000, max(400, util.rrange(newR - 500, newR + 500))
-            )  # used to be sooo much better/worse!
+            origR = min(3000, max(400, util.rrange(newR - 500, newR + 500)))
 
             self.__dict__[name] = {}
             days: int = (datetime.now() - u.createdAt).days

--- a/spamdb/modules/util.py
+++ b/spamdb/modules/util.py
@@ -31,10 +31,16 @@ def bulk_write(coll, objs, append=False):
     else:
         ledger = []
         for x in objs:
-            ledger.append(pymongo.DeleteOne({"_id": _dict(x)["_id"]}))
-            ledger.append(pymongo.InsertOne(_dict(x)))
-        res = coll.bulk_write(ledger)
-        print(f"{coll.name}: {res.bulk_api_result}")
+            ledger.append(
+                pymongo.UpdateOne(
+                    {"_id": _dict(x)["_id"]}, {"$set": _dict(x)}, upsert=True
+                )
+            )
+        res = coll.bulk_write(ledger).bulk_api_result
+        print(
+            f"{coll.name}: {{Upserted: {res['nUpserted']}, Matched: "
+            f"{res['nMatched']}, Modified: {res['nModified']}}}"
+        )
 
 
 # return a list of n semi-random ints >= minval which add up to sum

--- a/spamdb/spamdb.py
+++ b/spamdb/spamdb.py
@@ -27,42 +27,13 @@ def main():
         gen.set_bson_dump_mode(args.dump_bson)
 
     with _MongoContextMgr(args.uri) as db:
-
-        _do_drops(db, args.drop)
-
-        if not args.no_create:
-            user.create_user_colls(db, args.follow)
-            game.create_game_colls(db, int(args.games))
-            tour.create_tour_colls(db, int(args.tours))
-            forum.create_forum_colls(db, int(int(args.posts) / 2))
-            team.create_team_colls(db, int(int(args.posts) / 2))
-            blog.create_blog_colls(db, int(args.blogs))
-            event.create_event_colls(db)
-
-
-def _do_drops(db: pymongo.MongoClient, drop) -> None:
-    if drop == "game":
-        game.drop(db)
-    elif drop == "event":
-        event.drop(db)
-    elif drop == "forum":
-        forum.drop(db)
-    elif drop == "team":
-        team.drop(db)
-    elif drop == "user":
-        user.drop(db)
-    elif drop == "blog":
-        blog.drop(db)
-    elif drop == "tour":
-        tour.drop(db)
-    elif drop == "all":
-        tour.drop(db)
-        game.drop(db)
-        event.drop(db)
-        forum.drop(db)
-        team.drop(db)
-        user.drop(db)
-        blog.drop(db)
+        user.create_user_colls(db, args)  # args.follow)
+        game.create_game_colls(db, args)  # int(args.games))
+        tour.create_tour_colls(db, args)  # int(args.tours))
+        forum.create_forum_colls(db, args)  # int(int(args.posts) / 2))
+        team.create_team_colls(db, args)  # int(int(args.posts) / 2))
+        blog.create_blog_colls(db, args)  # int(args.blogs))
+        event.create_event_colls(db, args)
 
 
 class _MongoContextMgr:
@@ -188,17 +159,17 @@ def _get_args() -> argparse.Namespace:
     parser.add_argument(
         "--drop",
         help=(
-            "drop pre-existing collections prior to any update. see code "
+            "drop pre-existing collections prior to any update. see module code "
             "for specific collections dropped by each choice"
         ),
         choices=[
+            "all",
             "game",
             "event",
             "forum",
             "team",
             "user",
             "blog",
-            "all",
             "tour",
         ],
     )


### PR DESCRIPTION
password hash caching (just one salt per password now), and use upserts rather than deletes/inserts in bulk write.  trevlar said the old code was taking like 20 minutes on his pc, hope that's an exaggeration.  it's easy to get detached from ppl with hard drives and slower cpus.

update play counts so puzzles are daily eligible, blow open min/max ratings in puzzle path docs so that storm can select more than 3 or 4 of the thousands available