### PR TITLE
Seed games with Analysis flag set to false

### DIFF
--- a/spamdb/modules/game.py
+++ b/spamdb/modules/game.py
@@ -71,7 +71,7 @@ class Game:
         self.ua = util.time_shortly_after(self.ca)
         self.so = game["so"]
         self.hp = bson.binary.Binary(game["hp"])
-        self.an = game["an"]
+        self.an = False
         if "c" in game:
             self.c = bson.binary.Binary(game["c"])
         if "cw" in game:


### PR DESCRIPTION
The seeded games don't have an analysis, so this change prevents this from showing on the UI:

<img width="240" alt="Screen Shot 2022-09-03 at 9 48 14 AM" src="https://user-images.githubusercontent.com/271432/188273513-ee575c07-a679-4cbb-98a1-951fbf3f0999.png">
