### PR TITLE
Make wide username + id the same

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Usually, the script will generate a new set of data from inputs in the provided 
 - troll - marked as troll
 - bot0 thru bot9 - marked as bot
 - kid - they're just children, how could you checkmate children?
-- wide - 20 W's in visible username, WGM title, and a patron to test ui for extremely wide usernames.
+- wwwwwwwwwwwwwwwwwwww - 20 W's in visible username, WGM title, and a patron to test ui for extremely wide usernames.
 - and assorted others, see spamdb/modules/user.py for the full list
 
 ## Normal users:

--- a/spamdb/modules/user.py
+++ b/spamdb/modules/user.py
@@ -198,8 +198,8 @@ def _create_special_users():
     for i in range(10):
         users.append(User(f"bot{i}", [], [], False))
         users[-1].title = "BOT"
-    users.append(User("wide", [], [], False))
-    users[-1].username = "WWWWWWWWWWWWWWWWWWWW"  # widest possible i think
+    users.append(User("w"*20, [], [], False))
+    users[-1].username = "W"*20  # widest possible i think
     users[-1].title = "WGM"
     users[-1].plan["active"] = True  # patron
     users[-1].plan["months"] = 12


### PR DESCRIPTION
"wide" was probably used for easy login to this special account

It seems to cause issues with the search and mod tools when the `_id` and `username` are not in sync.