### PR TITLE
Update to work with new team permissions

### DIFF
--- a/spamdb/modules/team.py
+++ b/spamdb/modules/team.py
@@ -29,8 +29,11 @@ def update_team_colls() -> list:
 
         team_members = t.create_members(args.membership)
         for m in team_members:
-            if m.user != t.createdBy:
-                events.join_team(m.user, util.time_since(t.createdAt), t._id, t.name)
+            events.join_team(m.user, util.time_since(t.createdAt), t._id, t.name)
+            if m.user == t.createdBy:
+                setattr(m, 'perms', _leader_perms)
+            elif m.user in t.leaders:
+                setattr(m, 'perms', random.sample(_leader_perms, util.rrange(1, len(_leader_perms))))
         all_members.extend(team_members)
         remaining_topics = env.topics.copy()
         random.shuffle(remaining_topics)
@@ -100,3 +103,14 @@ class Team:
         )
         self.nbMembers = len(users)
         return [TeamMember(user, self._id) for user in users]
+
+_leader_perms: list[str] = [
+    "public",
+    "settings",
+    "tour",
+    "comm",
+    "request",
+    "pmall",
+    "kick",
+    "admin"
+]


### PR DESCRIPTION
Update to work with new team permissions. Only leaders should get the `perms` array (see [this commit](https://github.com/lichess-org/lila/commit/fe905a15a405579f1e987fa482f2d250e14406a7)) otherwise all team members show as permissionless leaders. Additionally, all leaders must be team members.

Team creators are given all permissions. Other leaders are given a random mixed bag of permissions.