### PR TITLE
Cap profile bio paragraph to 400 char limit

### DIFF
--- a/spamdb/modules/user.py
+++ b/spamdb/modules/user.py
@@ -90,7 +90,7 @@ class User:
         self.profile = {
             "country": env.random_country(),
             "location": self.username + " City",
-            "bio": env.random_paragraph(),
+            "bio": env.random_paragraph()[:400],
             "firstName": self.username,
             "lastName": self.username + "bertson",
             "fideRating": rating,


### PR DESCRIPTION
Caps paragraph bio at 400 chars to allow future profile saves without error.

The majority of paragraphs that are used for the profile bio are greater than 400 characters (which is the bio limit). When these are inserted into the database it works fine but if later you go to edit a profile you will get an error that the bio is greater than 400 chars.