### PR TITLE
Update test user email addresses

### DIFF
--- a/spamdb/modules/user.py
+++ b/spamdb/modules/user.py
@@ -73,7 +73,7 @@ class User:
     ):
         self._id = util.normalize_id(name)
         self.username = name.capitalize()
-        self.email = f"lichess.waste.basket+{name}@gmail.com" # sorry google
+        self.email = f"{name}@localhost"
         self.bpass = bson.binary.Binary(env.get_password_hash(name))
         self.enabled = True
         self.createdAt = util.time_since_days_ago()


### PR DESCRIPTION
Before Lichess looks up a user by their email address (for the password reset or magic login link), it normalizes the email address and [strips out the `+...` part](https://github.com/lichess-org/lila/blob/27900f333c89bdaf9e640c91aca5e449d6b74217/modules/common/src/main/EmailAddress.scala#L14-L15). So these test users couldn't receive those emails.

Fixes #29 