### PR TITLE
Changed clock to perf logic to match with that of lila

### DIFF
--- a/spamdb/modules/perf.py
+++ b/spamdb/modules/perf.py
@@ -23,8 +23,18 @@ types: list[list[int, str, float]] = [
 
 
 def clock_to_perf(init: int, inc: int) -> int:
-    # incorrectly map clock to perf type, just to reinforce that this is shit data
-    return 1 if init < 3 else 2 if init < 8 else 6 if init < 21 else 3 if init < 181 else 4
+    # correspondence games if any are still guessed incorrectly
+    total_game_time = init * 60 + inc * 40
+    if total_game_time < 30:
+        return 0
+    elif total_game_time < 180:
+        return 1
+    elif total_game_time < 480:
+        return 2
+    elif total_game_time < 1500:
+        return 6
+    else:
+        return 3
 
 class UserPerfs:
     def __init__(


### PR DESCRIPTION
Closes #48 . Correspondence games might still be guessed incorrectly. The logic was taken from https://github.com/lichess-org/lila/blob/a91335d86a260f02f8a334f857665491b4e19c87/ui/lobby/src/setupCtrl.ts#L26-L27 . While checking most of the games were shown correctly in search except one ¼+20 (Rapid) I am not sure why. But others are correct.
Thanks fitztrev for their help. 