### PR TITLE
Puzzle round seeder

### DIFF
--- a/spamdb/modules/puzzle.py
+++ b/spamdb/modules/puzzle.py
@@ -27,5 +27,5 @@ class PuzzleRound:
     def __init__(self, uid: str, pid: str):
         self._id = pid
         self.w = random.choice([True, False])
-        self.d = util.time_since_days_ago()
+        self.d = util.time_since_days_ago(10)
         self.u = uid

--- a/spamdb/modules/puzzle.py
+++ b/spamdb/modules/puzzle.py
@@ -13,9 +13,9 @@ def update_puzzle_colls() -> None:
     puzzles: list[PuzzleRound] = []
 
     for uid in env.uids:
-        puzzles = random.sample(env.puzzles, 10)
+        sample_puzzles = random.sample(env.puzzles, 10)
         for i in range(10):
-            pid = f"{uid}:{puzzles[i].get("_id")}"
+            pid = f"{uid}:{sample_puzzles[i].get("_id")}"
             puzzles.append(PuzzleRound(uid, pid))
 
     if args.no_create:

--- a/spamdb/modules/puzzle.py
+++ b/spamdb/modules/puzzle.py
@@ -12,9 +12,11 @@ def update_puzzle_colls() -> None:
 
     puzzles: list[PuzzleItem] = []
 
-    for (uid, pid) in (env.uids, env.puzzles):
+    for uid in env.uids:
         for _ in range(10):
-            puzzles.append(PuzzleItem(uid, pid._id))
+            puzzle = random.choice(env.puzzles)
+            pid = f"{uid}:{puzzle._id}"
+            puzzles.append(PuzzleItem(uid, pid))
 
     if args.no_create:
         return

--- a/spamdb/modules/puzzle.py
+++ b/spamdb/modules/puzzle.py
@@ -10,20 +10,20 @@ def update_puzzle_colls() -> None:
     if args.drop:
         db.puzzle2_round.drop()
 
-    puzzles: list[PuzzleItem] = []
+    puzzles: list[PuzzleRound] = []
 
     for uid in env.uids:
-        for _ in range(10):
-            puzzle = random.choice(env.puzzles)
-            pid = f"{uid}:{puzzle.get("_id")}"
-            puzzles.append(PuzzleItem(uid, pid))
+        puzzles = random.sample(env.puzzles, 10)
+        for i in range(10):
+            pid = f"{uid}:{puzzles[i].get("_id")}"
+            puzzles.append(PuzzleRound(uid, pid))
 
     if args.no_create:
         return
     
     util.bulk_write(db.puzzle2_round, puzzles)
 
-class PuzzleItem:
+class PuzzleRound:
     def __init__(self, uid: str, pid: str):
         self._id = pid
         self.w = random.choice([True, False])

--- a/spamdb/modules/puzzle.py
+++ b/spamdb/modules/puzzle.py
@@ -15,6 +15,7 @@ def update_puzzle_colls() -> None:
     for uid in env.uids:
         for _ in range(10):
             puzzle = random.choice(env.puzzles)
+            print(puzzle)
             pid = f"{uid}:{puzzle._id}"
             puzzles.append(PuzzleItem(uid, pid))
 

--- a/spamdb/modules/puzzle.py
+++ b/spamdb/modules/puzzle.py
@@ -1,0 +1,28 @@
+import random
+from modules.env import env
+import modules.util as util
+
+
+def update_puzzle_colls() -> None:
+    args = env.args
+    db = env.db
+    
+    if args.drop:
+        db.puzzle2_round.drop()
+
+    puzzles: list[PuzzleItem] = []
+
+    for uid in env.uids:
+        puzzles.append(PuzzleItem(uid))
+
+    if args.no_create:
+        return
+    
+    util.bulk_write(db.puzzle2_round, puzzles)
+
+class PuzzleItem:
+    def __init__(self, uid: str):
+        self._id = env.next_id(PuzzleItem)
+        self.w = random.choice([True, False])
+        self.d = util.time_since_days_ago()
+        self.u = uid

--- a/spamdb/modules/puzzle.py
+++ b/spamdb/modules/puzzle.py
@@ -15,8 +15,7 @@ def update_puzzle_colls() -> None:
     for uid in env.uids:
         for _ in range(10):
             puzzle = random.choice(env.puzzles)
-            print(puzzle)
-            pid = f"{uid}:{puzzle._id}"
+            pid = f"{uid}:{puzzle.get("_id")}"
             puzzles.append(PuzzleItem(uid, pid))
 
     if args.no_create:

--- a/spamdb/modules/puzzle.py
+++ b/spamdb/modules/puzzle.py
@@ -12,8 +12,9 @@ def update_puzzle_colls() -> None:
 
     puzzles: list[PuzzleItem] = []
 
-    for uid in env.uids:
-        puzzles.append(PuzzleItem(uid))
+    for (uid, pid) in (env.uids, env.puzzles):
+        for _ in range(10):
+            puzzles.append(PuzzleItem(uid, pid._id))
 
     if args.no_create:
         return
@@ -21,8 +22,8 @@ def update_puzzle_colls() -> None:
     util.bulk_write(db.puzzle2_round, puzzles)
 
 class PuzzleItem:
-    def __init__(self, uid: str):
-        self._id = env.next_id(PuzzleItem)
+    def __init__(self, uid: str, pid: str):
+        self._id = pid
         self.w = random.choice([True, False])
         self.d = util.time_since_days_ago()
         self.u = uid

--- a/spamdb/spamdb.py
+++ b/spamdb/spamdb.py
@@ -24,6 +24,7 @@ def main():
     import modules.blog as blog
     import modules.cms as cms
     import modules.feed as feed
+    import modules.puzzle as puzzle
     import modules.game as game
     import modules.team as team
     import modules.tour as tour
@@ -57,6 +58,7 @@ def main():
         msg.update_msg_colls()
         blog.update_blog_colls()
         feed.update_feed_colls()
+        puzzle.update_puzzle_colls()
         cms.update_cms_colls()
         event.update_event_colls()
         video.update_video_colls()


### PR DESCRIPTION
This PR adds a new module that applies the fake data of 10 randomly selected puzzle rounds to each user. This helps testing some puzzle-related endpoints like [puzzle dashboard](https://lichess.org/api#tag/Puzzles/operation/apiPuzzleDashboard). The code was put together quite quickly so feel free to roast my code and suggest improvements, I will happily implement them as long as they are in my skill range 😄.