### PR TITLE
Use ' instead of " in formatted string

### DIFF
--- a/spamdb/modules/puzzle.py
+++ b/spamdb/modules/puzzle.py
@@ -15,7 +15,7 @@ def update_puzzle_colls() -> None:
     for uid in env.uids:
         sample_puzzles = random.sample(env.puzzles, 10)
         for i in range(10):
-            pid = f"{uid}:{sample_puzzles[i].get("_id")}"
+            pid = f"{uid}:{sample_puzzles[i].get('_id')}"
             puzzles.append(PuzzleRound(uid, pid))
 
     if args.no_create:


### PR DESCRIPTION
Fixes this error:
```
5.865 Traceback (most recent call last):
5.865   File "/lila-db-seed/./spamdb/spamdb.py", line 70, in <module>
5.865     main()
5.865   File "/lila-db-seed/./spamdb/spamdb.py", line 27, in main
5.865     import modules.puzzle as puzzle
5.865   File "/lila-db-seed/spamdb/modules/puzzle.py", line 18
5.865     pid = f"{uid}:{sample_puzzles[i].get("_id")}"
5.865                                           ^^^
5.865 SyntaxError: f-string: unmatched '('
5.926 Traceback (most recent call last):
5.926   File "/lila-db-seed/./spamdb/spamdb.py", line 70, in <module>
5.926     main()
5.926   File "/lila-db-seed/./spamdb/spamdb.py", line 17, in main
5.926     subprocess.check_call([python_executable] + sys.argv)
5.926   File "/usr/lib/python3.10/subprocess.py", line 369, in check_call
5.927     raise CalledProcessError(retcode, cmd)
5.927 subprocess.CalledProcessError: Command '['/lila-db-seed/./spamdb/venv/bin/python', './spamdb/spamdb.py', '--drop-db', '--password=password', '--su-password=password', '--streamers', '--coaches', '--tokens']' returned non-zero exit status 1.
```