### PR TITLE
Specify simul index name to avoid conflict

### DIFF
--- a/spamdb/modules/simul.py
+++ b/spamdb/modules/simul.py
@@ -18,7 +18,7 @@ def update_simul_colls() -> None:
     if args.no_create:
         return
 
-    db.simul.create_index([("hostSeenAt", -1)])
+    db.simul.create_index([("hostSeenAt", -1)], name="spamdb_hostSeenAt")
     util.bulk_write(db.simul, simuls)
 
 class Simul:


### PR DESCRIPTION
~Resolves `TypeError: from_bytes() missing required argument 'byteorder' (pos 2)`~

Specifies a name to avoid conflict when the index is also created by [bin/mongodb/indexes.js](https://github.com/lichess-org/lila/blob/master/bin/mongodb/indexes.js)