### PR TITLE
create index needed for /study/topic/<topic>/mine

### DIFF
--- a/spamdb/modules/study.py
+++ b/spamdb/modules/study.py
@@ -18,7 +18,7 @@ def update_study_colls() -> list:
 
     if not args.no_create:
         util.bulk_write(db.study, study)
-        util.create_index(db.study, { "uids": 1,"rank": -1 } )
+        db.study.create_index({ "uids": 1,"rank": -1 })
         util.bulk_write(db.study_chapter_flat, env.practice_chapters)
         util.bulk_write(db.flag, [{"_id": "practice", "config": env.practice_config}]);
     return study

--- a/spamdb/modules/study.py
+++ b/spamdb/modules/study.py
@@ -18,6 +18,7 @@ def update_study_colls() -> list:
 
     if not args.no_create:
         util.bulk_write(db.study, study)
+        util.create_index(db.study, { "uids": 1,"rank": -1 } )
         util.bulk_write(db.study_chapter_flat, env.practice_chapters)
         util.bulk_write(db.flag, [{"_id": "practice", "config": env.practice_config}]);
     return study

--- a/spamdb/modules/util.py
+++ b/spamdb/modules/util.py
@@ -8,6 +8,13 @@ from datetime import timedelta, datetime
 from modules.env import env
 
 
+
+def create_index(
+    coll: pymongo.collection.Collection,
+    index: object
+) -> None:
+    coll.create_index(index)
+
 def bulk_write(
     coll: pymongo.collection.Collection,
     objs: list,

--- a/spamdb/modules/util.py
+++ b/spamdb/modules/util.py
@@ -9,12 +9,6 @@ from modules.env import env
 
 
 
-def create_index(
-    coll: pymongo.collection.Collection,
-    index: object
-) -> None:
-    coll.create_index(index)
-
 def bulk_write(
     coll: pymongo.collection.Collection,
     objs: list,


### PR DESCRIPTION
At the moment, accessing /study/topic/\<topic\>/mine after running spamdb will fail with following exception:

```
[info] 15:55:51.710 [warn] reactivemongo.api.Cursor - cannot continue after fatal request error
[info] reactivemongo.core.errors.DatabaseException$$anon$1: DatabaseException['error processing query: ns=lichess.study limit=16Tree: $and
[info]     topics $eq "class"
[info]     uids $eq "teacher"
[info] Sort: { rank: -1 }
[info] Proj: { uids: false, likers: false, rank: false }
[info]  planner returned error :: caused by :: hint provided does not correspond to an existing index' (code = 2)
```