### PR TITLE
Revert "add `web:mobile` scope to default token to allow testing all API endpoints"

### DIFF
--- a/spamdb/modules/user.py
+++ b/spamdb/modules/user.py
@@ -384,6 +384,5 @@ _scopes: list[str] = [
     'bot:play',
     'engine:read',
     'engine:write',
-    'web:mobile',
     'web:mod',
 ]


### PR DESCRIPTION
Fixes `oauth - declined token for ...` errors in local instances when trying to use one of the seeded test tokens. Use of `web:mobile` scope now requires a signed OAuth client.

Reverts lichess-org/lila-db-seed#76

