### PR TITLE
Add automod.quality to generated blog posts

### DIFF
--- a/spamdb/modules/blog.py
+++ b/spamdb/modules/blog.py
@@ -91,6 +91,7 @@ class UBlogPost:
         self.views = util.rrange(10, 100)
         self.likes = util.rrange(0, len(env.uids))
         self.likers = random.sample(env.uids, self.likes)
+        self.automod = {'quality': util.rrange(1, 3)}
         self.rank = self.created['at'] + timedelta(
             days=_tier_rank_day_bonus[tier],
             hours=math.sqrt(self.likes) + self.likes / 100,


### PR DESCRIPTION
Otherwise, contributors cannot see them in categories without first setting automod.quality=n in mongosh/ublog_post. There will still be confusion if they publish one and it never shows up, but this change should allow bug-fixing and testing of the browse UI.