### PR TITLE
Feature seeded blog posts so homepage carousel has content

### DIFF
--- a/spamdb/modules/blog.py
+++ b/spamdb/modules/blog.py
@@ -1,6 +1,6 @@
 import random
 import math
-from datetime import timedelta
+from datetime import datetime, timedelta
 from modules.event import events
 from modules.env import env
 import modules.forum as forum
@@ -56,6 +56,23 @@ def update_blog_colls() -> None:
         for ft in ftopics:
             categ.add_topic(ft)
 
+    # Feature a handful of posts so the homepage carousel has content.
+    # Carousel query needs live posts with featured.until >= now (pinned)
+    # or featured.at >= now - 1 month (queue). See lila UblogApi.fetchCarouselFromDb.
+    live_posts = [up for up in uposts if up.live]
+    carousel_target = min(9, len(live_posts))
+    now = datetime.now()
+    for i, up in enumerate(random.sample(live_posts, carousel_target)):
+        # Random author, lightly skewed toward the lichess system account,
+        # since any community blog can be elevated to the carousel.
+        by = 'lichess' if random.random() < 0.25 else env.random_uid()
+        if i < carousel_target // 2:
+            # pinned: currently featured, stays up for a while
+            up.featured = {'by': by, 'at': now, 'until': now + timedelta(days=util.rrange(7, 30))}
+        else:
+            # queue: featured recently, no active pin
+            up.featured = {'by': by, 'at': now - timedelta(days=util.rrange(0, 25))}
+
     if args.no_create:
         return
 
@@ -96,6 +113,7 @@ class UBlogPost:
             days=_tier_rank_day_bonus[tier],
             hours=math.sqrt(self.likes) + self.likes / 100,
         )
+        self.featured = None
 
 
 _tier_distributions: list[float] = [0.0, 0.05, 0.5, 0.2, 0.1, 0.05]


### PR DESCRIPTION
Fixes #81
The homepage blog carousel renders empty because the seed never marks any post as featured. lila's carousel query (UblogApi.fetchCarouselFromDb) selects live posts with either featured.until >= now (pinned) or featured.at within the last month (queue). Since UBlogPost never sets a featured subdocument, both queries return nothing.
This features a handful of seeded posts (up to the carousel default of 9), split between pinned (future until) and queue (recent at), matching the Featured(by, at, until) shape lila expects. Per discussion in #81, the featuring user is a random uid with a light skew toward the lichess system account, since any community blog can be elevated to the carousel.
Verified locally against the exact queries in UblogApi.fetchCarouselFromDb: seeded posts now produce featured documents that populate both carousel buckets (pinned featured.until >= now, queue featured.at within the last month), filling the carousel to its default size of 9. Non-live posts are correctly excluded, and the featured.by skew toward the lichess user works as intended.